### PR TITLE
Remove my API Key from mbta_redline_status.py

### DIFF
--- a/mbta_redline_status.py
+++ b/mbta_redline_status.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 API_URL = "https://api-v3.mbta.com/alerts?filter[route]=Red"
 
 # My MBTA Developer API key
-API_KEY = "3b210c66cb154a1cbdbf6f482b582f55"
+API_KEY = "" # Add MBTA API Key here.  Obtain a free API key at https://api-v3.mbta.com/
 
 def check_red_line_disruptions():
     headers = {


### PR DESCRIPTION
Remove my API key from Line 5, add a comment for where to get an MBTA developer API key for users that don't already have one